### PR TITLE
Remove logical double call of updateBottomBar()

### DIFF
--- a/src/com/example/android/wizardpager/MainActivity.java
+++ b/src/com/example/android/wizardpager/MainActivity.java
@@ -133,7 +133,6 @@ public class MainActivity extends FragmentActivity implements
         });
 
         onPageTreeChanged();
-        updateBottomBar();
     }
 
     @Override


### PR DESCRIPTION
`updateBottomBar()` is called in `onPageTreeChanged()` anyway so we don't have to call it in `onCreate()`
